### PR TITLE
Fix for the missing stylesheets problem

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title:               Amelia Meyer
 tagline:             'UCSB Student'
 description:         'Statistics and Data Science Major, German Minor'
 url:                 'http://ameliameyer.github.io'
-baseurl:             '/ameliameyer.github.io'
+baseurl:             ''
 paginate:            5
 permalink:           pretty
 


### PR DESCRIPTION
The stylesheets weren't loading because of incorrect URLs in the generated pages. For instance, the URL for `lanyon.css` was generated as `http://ameliameyer.github.io/ameliameyer.github.io/public/css/lanyon.css`. Setting the `baseurl` to `''` fixes this problem.